### PR TITLE
WIP on allowing cells to be edited with a popup menu

### DIFF
--- a/MBTableGrid.h
+++ b/MBTableGrid.h
@@ -635,6 +635,18 @@ typedef enum {
 @optional
 
 /**
+ *  @brief
+ *
+ *  @param aTableGrid  The table grid that sent the message.
+ *  @param columnIndex A column in \c aTableGrid.
+ *
+ *  @return An array of possible object values to represent in a popup button for a given column. Return nil if the cells in the column should not be edited with a popup button of available values, but should instead allow freeform string input. The count of the returned array should match that returned in tableGrid:availableUserStringsForColumn:.
+ */
+- (NSArray *)tableGrid:(MBTableGrid *)aTableGrid availableObjectValuesForColumn:(NSUInteger)columnIndex;
+
+@optional
+
+/**
  * @brief		Returns the background color for the specified column and row.
  *
  * @param		aTableGrid		The table grid that sent the message.

--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -52,6 +52,7 @@ NSString *MBTableGridRowDataType = @"MBTableGridRowDataType";
 - (NSString *)_headerStringForRow:(NSUInteger)rowIndex;
 - (id)_objectValueForColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 - (NSFormatter *)_formatterForColumn:(NSUInteger)columnIndex;
+- (NSArray *)_availableObjectValuesForColumn:(NSUInteger)columnIndex;
 - (void)_setObjectValue:(id)value forColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex;
 - (float)_widthForColumn:(NSUInteger)columnIndex;
 - (float)_setWidthForColumn:(NSUInteger)columnIndex;
@@ -1348,6 +1349,13 @@ NSString *MBTableGridRowDataType = @"MBTableGridRowDataType";
         return [[self dataSource] tableGrid:self formatterForColumn:columnIndex];
     }
     return nil;
+}
+
+- (NSArray *)_availableObjectValuesForColumn:(NSUInteger)columnIndex {
+	if ([[self dataSource] respondsToSelector:@selector(tableGrid:availableObjectValuesForColumn:)]) {
+		return [[self dataSource] tableGrid:self availableObjectValuesForColumn:columnIndex];
+	}
+	return nil;
 }
 
 - (id)_backgroundColorForColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex {

--- a/MBTableGridCell.h
+++ b/MBTableGridCell.h
@@ -34,6 +34,8 @@
     
 }
 
+@property(nonatomic, assign) BOOL editWithPopupMenu;
+
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView withBackgroundColor:(NSColor *)backgroundColor;
 
 @end

--- a/MBTableGridCell.m
+++ b/MBTableGridCell.m
@@ -63,6 +63,25 @@
 	// Draw the bottom border
 	NSRect bottomLine = NSMakeRect(NSMinX(cellFrame), NSMaxY(cellFrame)-1.0, NSWidth(cellFrame), 1.0);
 	NSRectFill(bottomLine);
+
+	// Draw arrows to indicate that this cell is edited with a popup menu.
+	// Also move the right edge of the cell frame to the left so that the
+	// interior is drawn inside and it doesn't overlap the arrows on the right.
+	if (self.editWithPopupMenu) {
+		NSImage *upArrowImage = [NSImage imageNamed:@"sort-desc"];
+		NSImage *downArrowImage = [NSImage imageNamed:@"sort-asc"];
+
+		CGFloat maxArrowWidth = fmax(upArrowImage.size.width, downArrowImage.size.width);
+		CGFloat arrowX = CGRectGetMaxX(cellFrame) - maxArrowWidth;
+		CGFloat upY = CGRectGetMaxY(cellFrame) - upArrowImage.size.height;
+		[upArrowImage drawInRect:NSMakeRect(arrowX, upY, upArrowImage.size.width, upArrowImage.size.height)];
+		CGFloat downY = CGRectGetMinY(cellFrame);
+		[downArrowImage drawInRect:NSMakeRect(arrowX, downY, downArrowImage.size.width, downArrowImage.size.height)];
+
+		CGRect slice, remainder;
+		CGRectDivide(cellFrame, &slice, &remainder, maxArrowWidth, CGRectMaxXEdge);
+		cellFrame = remainder;
+	}
     
 	[self drawInteriorWithFrame:cellFrame inView:controlView];
 }

--- a/MBTableGridController.m
+++ b/MBTableGridController.m
@@ -129,11 +129,19 @@
 
 - (NSFormatter *)tableGrid:(MBTableGrid *)aTableGrid formatterForColumn:(NSUInteger)columnIndex
 {
-    if (columnIndex >= 4) {
+    if (columnIndex >= 2) {
         return nil;
     }
 
     return formatters[columnIndex % [formatters count]];
+}
+
+- (NSArray *)tableGrid:(MBTableGrid *)aTableGrid availableObjectValuesForColumn:(NSUInteger)columnIndex
+{
+	if (columnIndex == 2) {
+		return @[ @"Action & Adventure", @"Comedy", @"Romance", @"Thriller" ];
+	}
+	return nil;
 }
 
 - (void)tableGrid:(MBTableGrid *)aTableGrid setObjectValue:(id)anObject forColumn:(NSUInteger)columnIndex row:(NSUInteger)rowIndex


### PR DESCRIPTION
![screenshot 2014-09-10 09 57 31](https://cloud.githubusercontent.com/assets/594059/4220708/32e6bf5a-3903-11e4-8d81-cdfad31306cf.png)

There is currently a delegate method to provide whether a cell has "available object values" (what will be presented as menu items in a popup menu). This can be used to return the values or nil (for "edit as text"). Cells with available values will display with arrows as an affordance to the user.

Todo:
- [ ] Popup cells should allow clicking the arrows once to show the popup menu (and maybe explicitly not allowing double click?)
- [ ] Cancelling the popup menu should reset the editedColumn/Row ivars so that
  the cell gets redrawn (cells at those ivar coordinates are skipped in
  drawRect:)
