### PR TITLE
Editing checkboxes occurs immediately on (first, or any) mouse down

### DIFF
--- a/MBButtonCell.h
+++ b/MBButtonCell.h
@@ -6,8 +6,12 @@
 //
 //
 
-#import <Cocoa/Cocoa.h>
+#import "MBTableGridEditable.h"
 
-@interface MBButtonCell : NSButtonCell
+@interface MBButtonCell : NSButtonCell <MBTableGridEditable>
+
+#pragma mark - MBTableGridEditable
+
+@property (nonatomic, assign, readonly) BOOL editOnFirstClick;
 
 @end

--- a/MBButtonCell.m
+++ b/MBButtonCell.m
@@ -10,6 +10,8 @@
 
 @implementation MBButtonCell
 
+#pragma mark - Lifecycle
+
 - (instancetype)init {
 	self = [super init];
 	if (self) {
@@ -20,6 +22,14 @@
 	}
 	return self;
 }
+
+#pragma mark - MBTableGridEditable
+
+- (BOOL)editOnFirstClick {
+    return YES;
+}
+
+#pragma mark - NSCell
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView withBackgroundColor:(NSColor *)backgroundColor
 {
@@ -32,12 +42,7 @@
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
 {
-	NSRect popupFrame = cellFrame;
-	popupFrame.size.width = 16;
-	popupFrame.size.height = 16;
-	popupFrame.origin.x = cellFrame.origin.x + (cellFrame.size.width / 2 - 8);
-	popupFrame.origin.y = cellFrame.origin.y + (cellFrame.size.height / 2 - 8);
-	
+	NSRect popupFrame = [self centeredButtonRectInCellFrame:cellFrame];
 	[super drawWithFrame:popupFrame inView:controlView];
 	
 	NSColor *borderColor = [NSColor colorWithDeviceWhite:0.83 alpha:1.0];
@@ -58,6 +63,23 @@
 {
 	// Do not draw any highlight.
 	return nil;
+}
+
+- (NSCellHitResult)hitTestForEvent:(NSEvent *)event inRect:(NSRect)cellFrame ofView:(NSView *)controlView {
+    NSRect centeredButtonRect = [self centeredButtonRectInCellFrame:cellFrame];
+    CGPoint eventLocationInControlView = [controlView convertPoint:event.locationInWindow fromView:nil];
+    return CGRectContainsPoint(centeredButtonRect, eventLocationInControlView) ? NSCellHitContentArea : NSCellHitNone;
+}
+
+#pragma mark - Private
+
+- (NSRect)centeredButtonRectInCellFrame:(NSRect)cellFrame {
+    NSRect centeredFrame = cellFrame;
+    centeredFrame.size.width = 16;
+    centeredFrame.size.height = 16;
+    centeredFrame.origin.x = cellFrame.origin.x + (cellFrame.size.width - centeredFrame.size.width) / 2;
+    centeredFrame.origin.y = cellFrame.origin.y + (cellFrame.size.height - centeredFrame.size.height) / 2;
+    return centeredFrame;
 }
 
 @end

--- a/MBTableGrid.xcodeproj/project.pbxproj
+++ b/MBTableGrid.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C646838118DB8658008700EF /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C646837D18DB862A008700EF /* QuartzCore.framework */; };
 		C646838218DB8897008700EF /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C646837D18DB862A008700EF /* QuartzCore.framework */; };
 		C9412A5F0D8AE98C00E9E614 /* MBTableGridController.m in Sources */ = {isa = PBXBuildFile; fileRef = C9412A5E0D8AE98C00E9E614 /* MBTableGridController.m */; };
+		CA46E3621A09726A00C43B4B /* MBTableGridEditable.h in Headers */ = {isa = PBXBuildFile; fileRef = CA46E3611A09726A00C43B4B /* MBTableGridEditable.h */; };
 		E2E62BAC1781C33500F36275 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2E62BAB1781C33400F36275 /* Cocoa.framework */; };
 		E2E62BB21781C33500F36275 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E2E62BB01781C33500F36275 /* InfoPlist.strings */; };
 		E2E62BBA1781C37300F36275 /* MBTableGrid.m in Sources */ = {isa = PBXBuildFile; fileRef = C9412A3E0D8A061C00E9E614 /* MBTableGrid.m */; };
@@ -70,6 +71,7 @@
 		C9412B390D8B2F5400E9E614 /* MBTableGridHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBTableGridHeaderView.m; sourceTree = SOURCE_ROOT; };
 		C9412D7B0D8B5AB900E9E614 /* MBTableGridCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBTableGridCell.h; sourceTree = SOURCE_ROOT; };
 		C9412D7C0D8B5AB900E9E614 /* MBTableGridCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBTableGridCell.m; sourceTree = SOURCE_ROOT; };
+		CA46E3611A09726A00C43B4B /* MBTableGridEditable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBTableGridEditable.h; sourceTree = SOURCE_ROOT; };
 		E2E62BAA1781C33400F36275 /* MBTableGrid.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MBTableGrid.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2E62BAB1781C33400F36275 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		E2E62BAF1781C33500F36275 /* MBTableGrid-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "MBTableGrid-Info.plist"; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				C639542B19FF3B7C0029BDF1 /* MBPopupButtonCell.m */,
 				C639542E19FF84FA0029BDF1 /* MBButtonCell.h */,
 				C639542F19FF84FA0029BDF1 /* MBButtonCell.m */,
+				CA46E3611A09726A00C43B4B /* MBTableGridEditable.h */,
 				E2E62BAE1781C33500F36275 /* Supporting Files */,
 			);
 			path = MBTableGrid;
@@ -225,6 +228,7 @@
 			files = (
 				E2E62BF71781C53800F36275 /* MBTableGrid.h in Headers */,
 				C639543019FF84FA0029BDF1 /* MBButtonCell.h in Headers */,
+				CA46E3621A09726A00C43B4B /* MBTableGridEditable.h in Headers */,
 				E2E62BF81781C53800F36275 /* MBTableGridContentView.h in Headers */,
 				C639542C19FF3B7C0029BDF1 /* MBPopupButtonCell.h in Headers */,
 				E2E62BF91781C53800F36275 /* MBTableGridHeaderView.h in Headers */,

--- a/MBTableGridEditable.h
+++ b/MBTableGridEditable.h
@@ -1,0 +1,19 @@
+//
+//  MBTableGridEditable.h
+//  MBTableGrid
+//
+//  Created by Brandon Evans on 2014-11-04.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol MBTableGridEditable <NSObject>
+
+@optional
+/**
+ *  If a cell should be edited when the user first clicks in the cell (like a checkbox instead of a text field), return YES. If you return YES then it's recommended that your cell override `- hitTestForEvent:inRect:ofView:` to verify whether or not the location of the mouse is correct to edit the cell. For example, a checkbox cell would return YES from `- hitTestForEvent:inRect:ofView:` if the mouse was in the frame of the checkbox itself and NO if it was elsewhere in the cell or outside the cell.
+ */
+@property (nonatomic, assign, readonly) BOOL editOnFirstClick;
+
+@end


### PR DESCRIPTION
Add a protocol that cells can implement to provide whether they should edit
immediately on first mouse down. MBButtonCell is the first cell to implement
this and also overrides `- hitTestForEvent:inRect:ofView:` to provide whether
the mouse event was in the cell or also in the checkbox frame (thus toggling the
state). I'm imagining this protocol and method also being used with popup button cells to enable showing the popup menu (edit state) when the arrows are clicked even if the cell isn't already selected.

Some of the logic in mouseDown: and editSelectedCell was rearranged to support this, and I think there's probably some further refactoring that could happen in those methods.

Fixes #5.

![](https://dl.dropboxusercontent.com/s/3kglda8clxo7cag/62032FDB-B76D-4C0B-855B-E783267E4E2B-53540-00016EB8D88EFF1C.gif?dl=0)
