### PR TITLE
Tab and enter end text editing and move right, down respectively

### DIFF
--- a/MBTableGrid.m
+++ b/MBTableGrid.m
@@ -84,7 +84,6 @@ NSString *MBTableGridRowDataType = @"MBTableGridRowDataType";
 - (void)_setDropRow:(NSInteger)rowIndex;
 @end
 
-
 @implementation MBTableGrid
 
 @synthesize allowsMultipleSelection;
@@ -735,7 +734,8 @@ NSString *MBTableGridRowDataType = @"MBTableGridRowDataType";
 	[contentView editSelectedCell:self];
 
 	// Insert the typed string into the field editor
-	NSText *fieldEditor = [[self window] fieldEditor:YES forObject:self];
+	NSText *fieldEditor = [[self window] fieldEditor:YES forObject:contentView];
+	fieldEditor.delegate = contentView;
 	[fieldEditor setString:aString];
 
     [self setNeedsDisplay:YES];

--- a/MBTableGridContentView.h
+++ b/MBTableGridContentView.h
@@ -38,7 +38,7 @@
  *				and editing capabilities of MBTableGrid. It is designed
  *				to be placed inside a scroll view.
  */
-@interface MBTableGridContentView : NSView {
+@interface MBTableGridContentView : NSView <NSTextDelegate> {
 	NSInteger mouseDownColumn;
 	NSInteger mouseDownRow;
 	

--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -465,6 +465,18 @@
 	
 	// End the editing session
 	[[[self tableGrid] cell] endEditing:[[self window] fieldEditor:NO forObject:self]];
+
+	NSInteger movementType = [aNotification.userInfo[@"NSTextMovement"] integerValue];
+	switch (movementType) {
+		case NSTabTextMovement:
+			[[self tableGrid] moveRight:self];
+			break;
+		case NSReturnTextMovement:
+			[[self tableGrid] moveDown:self];
+			break;
+		default:
+			break;
+	}
 }
 
 #pragma mark -
@@ -581,6 +593,7 @@
 
 	} else {
 		NSText *editor = [[self window] fieldEditor:YES forObject:self];
+		editor.delegate = self;
 		[selectedCell editWithFrame:cellFrame inView:self editor:editor delegate:self event:nil];
 	}
 }


### PR DESCRIPTION
Fixed delegate setup to be consistent and use the existing delegate method for both cases (double click to start editing, just start typing to start editing). Use the notification info to figure out which way to move the selected cell and do that after persisting the edited data.

Fixes #13.

![](https://dl.dropboxusercontent.com/s/6qrby8rf475e7q4/486B5E99-0F74-443E-9152-8220617D232A-53540-000171E58523615F.gif?dl=0)
