### PR TITLE
Set the field editor's string value when double-click editing a text cell

### DIFF
--- a/MBTableGridContentView.m
+++ b/MBTableGridContentView.m
@@ -595,6 +595,7 @@
 		NSText *editor = [[self window] fieldEditor:YES forObject:self];
 		editor.delegate = self;
 		[selectedCell editWithFrame:cellFrame inView:self editor:editor delegate:self event:nil];
+		editor.string = currentValue;
 	}
 }
 


### PR DESCRIPTION
Fixes #21.
